### PR TITLE
Remove AppIdentityServiceFailureException from coverage.  The remaining ...

### DIFF
--- a/tests/appengine-tck-appidentity/src/test/resources/coverage.txt
+++ b/tests/appengine-tck-appidentity/src/test/resources/coverage.txt
@@ -3,4 +3,5 @@ com.google.appengine.api.appidentity.AppIdentityService$GetAccessTokenResult
 com.google.appengine.api.appidentity.AppIdentityService$ParsedAppId
 com.google.appengine.api.appidentity.AppIdentityService$SigningResult
 com.google.appengine.api.appidentity.PublicCertificate
-com.google.appengine.api.appidentity.AppIdentityServiceFailureException
+
+#com.google.appengine.api.appidentity.AppIdentityServiceFailureException


### PR DESCRIPTION
...uncovered constructors are something user would not call.
