### PR TITLE
Don't check BCC at all

### DIFF
--- a/tests/appengine-tck-mail/src/test/java/com/google/appengine/tck/mail/MailServiceTest.java
+++ b/tests/appengine-tck-mail/src/test/java/com/google/appengine/tck/mail/MailServiceTest.java
@@ -397,7 +397,6 @@ public class MailServiceTest extends MailTestBase {
                     || !Objects.equals(expectedMimeProps.from, mp.from)
                     || !Objects.equals(expectedMimeProps.to, mp.to)
                     || !Objects.equals(expectedMimeProps.cc, mp.cc)
-                    || !Objects.equals(MimeProperties.BLANK, mp.bcc) // also, the to: and cc: would fail if bcc: was added to them.
                     || !Objects.equals(expectedReplyTo, mp.replyTo)) {
                     return false;
                 }


### PR DESCRIPTION
Since the BCC field should be removed by the destination server, we shouldn't use it to match received email messages with the expected email message. GMail used to strip the BCC, but now it apparently doesn't strip it if it's the same as the sender's address.
