### PR TITLE
Server welcome file (index.html) from a folder

### DIFF
--- a/core/misc/src/test/java/com/google/appengine/tck/misc/staticfiles/IncludeIndexFileTest.java
+++ b/core/misc/src/test/java/com/google/appengine/tck/misc/staticfiles/IncludeIndexFileTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.appengine.tck.misc.staticfiles;
+
+import java.net.URL;
+
+import com.google.appengine.tck.base.TestContext;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class IncludeIndexFileTest extends StaticFilesTestBase {
+
+    @Deployment
+    public static WebArchive getDeployment() {
+        WebArchive archive = getTckDeployment(new TestContext()
+            .setAppEngineWebXmlFile("appengine-web-nostaticfiles.xml"));
+        createFile(archive, "/foo/index.html");
+        return archive;
+    }
+
+    @Test
+    @RunAsClient
+    public void testAllFilesIncludedByDefault(@ArquillianResource URL url) throws Exception {
+        assertPageFound(url, "foo/");
+        assertPageFound(url, "foo/index.html");
+    }
+
+}

--- a/core/misc/src/test/java/com/google/appengine/tck/misc/staticfiles/IncludeIndexFileTest.java
+++ b/core/misc/src/test/java/com/google/appengine/tck/misc/staticfiles/IncludeIndexFileTest.java
@@ -18,6 +18,7 @@ package com.google.appengine.tck.misc.staticfiles;
 import java.net.URL;
 
 import com.google.appengine.tck.base.TestContext;
+import com.google.appengine.tck.login.UserIsLoggedIn;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -32,16 +33,17 @@ public class IncludeIndexFileTest extends StaticFilesTestBase {
     @Deployment
     public static WebArchive getDeployment() {
         WebArchive archive = getTckDeployment(new TestContext()
-            .setAppEngineWebXmlFile("appengine-web-nostaticfiles.xml"));
-        createFile(archive, "/foo/index.html");
+            .setAppEngineWebXmlFile("appengine-web-admin-staticfiles.xml")
+	    .setWebXmlFile("web-security-constraint.xml"));
+        createFile(archive, "/admin/index.html");
         return archive;
     }
 
     @Test
     @RunAsClient
+    @UserIsLoggedIn(email = "${user.login.email:${appengine.userId:tck@appengine-tck.org}}", isAdmin = true)
     public void testAllFilesIncludedByDefault(@ArquillianResource URL url) throws Exception {
-        assertPageFound(url, "foo/");
-        assertPageFound(url, "foo/index.html");
+        assertPageFound(url, "admin/index.html");
     }
 
 }

--- a/core/misc/src/test/resources/appengine-web-admin-staticfiles.xml
+++ b/core/misc/src/test/resources/appengine-web-admin-staticfiles.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Google Inc. All Rights Reserved.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+    <application>tckapp</application>
+    <version>1</version>
+    <threadsafe>true</threadsafe>
+
+    <warmup-requests-enabled>false</warmup-requests-enabled>
+
+    <static-files>
+    </static-files>
+
+</appengine-web-app>

--- a/core/misc/src/test/resources/web-security-constraint.xml
+++ b/core/misc/src/test/resources/web-security-constraint.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2015 Google Inc. All Rights Reserved.
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+         id="cloud-test-compatibility-kit" version="2.5">
+    <security-constraint>
+        <web-resource-collection>
+            <url-pattern>/admin/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>*</role-name>
+        </auth-constraint>
+    </security-constraint>
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+    </welcome-file-list>
+</web-app>


### PR DESCRIPTION
A sample test to serve an `index.html` within a physical folder in the project